### PR TITLE
New path name for GoogleVR camera

### DIFF
--- a/CardboardControl/README.md
+++ b/CardboardControl/README.md
@@ -9,7 +9,7 @@ Cardboard Controls+ is all you need to develop the best Cardboard games in Unity
 - Remove existing Cardboard Controls+ files to ensure that they get updated properly
 - Import [the latest unitypackage](https://github.com/JScott/cardboard-controls/releases/latest)
 - Add `CardboardControl/Prefabs/CardboardControlManager` to the root of your scene
-- Replace your Camera with `Cardboard/Prefabs/CardboardMain`
+- Replace your Camera with `GoogleVR/Prefabs/GvrMain`
 - Use the [API](API.md) which is explained in [the Demo Scene code comments](CardboardControl/DemoScenes/Scripts/ExampleCharacterController.cs).
 
 You may experience problems if you import the code manually without using the provided unitypackage file.


### PR DESCRIPTION
Cardboard has changed to GoogleVR now that they have added additional support for the upcoming Daydream
